### PR TITLE
Fix Critical vulnerability (Password Disclosure)

### DIFF
--- a/index.php
+++ b/index.php
@@ -82,7 +82,7 @@ foreach ($wCMS->config as $key => $val) {
 				}
 			}
 
-			if (strpos($_SERVER['REQUEST_URI'], 'password') !== false) {
+			if (strtolower($val) == 'password') {
 				header('Location: ./');
 				exit;
 			}


### PR DESCRIPTION
If you access: https://wondercms.com/demo/PASSWORD
or https://wondercms.com/demo/PASSWORD

I've included a fix for the vulnerability, I suggest to check whether the page itself (transform to lowercase!) that is going to be displayed is the password.

(Someone try my fix and let me know if it works).

And I HIGHLY suggest to separate the site configuration from the user pages.