### PR TITLE
Password (hash) Disclosure (closed and fix pushed)

### DIFF
--- a/index.php
+++ b/index.php
@@ -82,11 +82,6 @@ foreach ($wCMS->config as $key => $val) {
 				}
 			}
 
-			if (strpos(strtolower($_SERVER['REQUEST_URI']), 'password') !== false)  {
-				header('Location: ./');
-				exit;
-			}
-
 			if (!isset($wCMS->config->content)) {
 				if (empty($wCMS->config->menu)) $wCMS->config->menu = "undeletable page";
 				if (!isset($wCMS->config->{$wCMS->config->currentPage})) {
@@ -243,6 +238,9 @@ function host() {
 
 	$wCMS->host = $host;
 	$wCMS->requestedPage = $rp;
+	if ($rp == 'password') {
+		$wCMS->requestedPage = '404';
+	}
 	$wCMS->config->currentPage = getSlug(($wCMS->requestedPage) ? $wCMS->requestedPage : $wCMS->config->page);
 }
 


### PR DESCRIPTION
Due to the bad stripping and conditioning, again there is a password disclosure with multiple ways:
https://wondercms.com/demo/pass<word
https://wondercms.com/demo/p\assword
https://wondercms.com/demo/pass=word
...etc

So, I came across the best solution as I said earlier to do the checks on the requested page itself AFTER the stripping ...etc
I discovered many other errors and bad practices but I can't find time to push all of them.

I think the best solution is to use the version I built:
https://github.com/yassineaddi/wondercms

I built it with security in mind, all the vuls are patched and tested all of them. It's OOP which means easy to build plugins over it ...etc and better for developers who wants to use it as a skeleton. Please take a few minutes to test it.

I highly suggest to use it instead and implement the new features over it which is very easy and I'm here of help if needed.