### PR TITLE
Better README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@
   - Supports plugins ([hooks/listeners](https://github.com/robiso/wondercms/wiki/List-of-hooks)), [themes](https://github.com/robiso/wondercms/wiki/Create-theme-in-8-easy-steps), [backups](https://github.com/robiso/wondercms/wiki/Backup-all-files), [1 click updates](https://github.com/robiso/wondercms/wiki/One-click-update).
   - Project goal: keep it simple, tiny, hassle free (infrequent-ish 1 click updates).
 
+## Requirements
+- PHP version 7.1 or greater with:
+  - cURL extension
+  - mbstring extension
+  - Zip extension
+- A webserver:
+  - Apache with module `rewrite` and `AllowOverride All` directive
+  - or NGINX [see configuration setup](https://github.com/robiso/wondercms/wiki/NGINX-server-config)
+  - or IIS [see configuration setup](https://github.com/robiso/wondercms/wiki/IIS-server-config)
+
+**WonderCMS works on most Apache servers/hosts (even free ones) out of the box.**
+
 ## Installation
 
 ### From ZIP archive
@@ -56,20 +68,6 @@ Get hosting with WonderCMS pre-installed -> https://www.wondercms.com/hosting (A
 ### Deploy on Microsoft Azure
 
 See instructions on [Microsoft.com](https://azure.microsoft.com/en-gb/try/app-service/web/wondercms/?Language=php&Step=template).
-
-## Requirements
-- PHP 7.1 or greater
-  - cURL extension
-  - mbstring extension
-  - Zip extension
-- mod_rewrite module
-- any type of server (Apache, NGINX or IIS)
-
-*For setting up WonderCMS on NGINX or IIS servers, there is 1 additional step required. Read more: [NGINX setup](https://github.com/robiso/wondercms/wiki/NGINX-server-config) or [IIS setup](https://github.com/robiso/wondercms/wiki/IIS-server-config).*
-
-**WonderCMS works on most Apache servers/hosts (even free ones) by default.
-It will also work with lower PHP versions (5.5+), but we highly advise against using unsupported PHP versions.**
-
 
 ## Libraries used (6)
 Libraries are loaded from Content Delivery Networks (CDNs) and include [SRI tags](https://github.com/robiso/wondercms/wiki/Add-SRI-tags-to-your-theme-libraries#3-steps-for-more-security).


### PR DESCRIPTION
* requirements should be before installation step
* associate the rewrite module to Apache
* add mention of AllowOverride as the default is None after 2.3.9
* remove mention of the software working before 5.5 as this is an
implicit permission to run it on insecure versions. Not having this
sentence also allows using the latest 7.1+ features of PHP in future
work. The minimum PHP version must be hard requirement.