### PR TITLE
Fix bad parenthesis on catch line

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,6 +19,6 @@ try {
     $Wcms = new Wcms();
     $Wcms->init();
     $Wcms->render();
-} catch Exception($e) {
+} catch (Exception $e) {
     echo $e->getMessage();
 }


### PR DESCRIPTION
That's what you get when editing code and not running it… Also, this
kind of silly error would be catched immediatly if there was some
automated tests! :)

It's interesting how I've written this line at least a hundred time but still manage to fail it…