### PR TITLE
Add custom exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Robiso\\Wondercms\\" : ["src/classes"]
+            "Robiso\\Wondercms\\" : ["src/classes"],
+            "Robiso\\Wondercms\\Exceptions\\" : ["src/exceptions"]
         }
     },
     "license": "MIT"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "138f16a20acb2f39d21aa5fa5d84969a",
+    "content-hash": "9451a6be5ee379e62ccd8aefe962a25e",
     "packages": [
         {
             "name": "symfony/http-foundation",
-            "version": "v4.2.2",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "a633d422a09242064ba24e44a6e1494c5126de86"
+                "reference": "8d2318b73e0a1bc75baa699d00ebe2ae8b595a39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a633d422a09242064ba24e44a6e1494c5126de86",
-                "reference": "a633d422a09242064ba24e44a6e1494c5126de86",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8d2318b73e0a1bc75baa699d00ebe2ae8b595a39",
+                "reference": "8d2318b73e0a1bc75baa699d00ebe2ae8b595a39",
                 "shasum": ""
             },
             "require": {
@@ -58,7 +58,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-05T16:37:49+00:00"
+            "time": "2019-01-29T09:49:29+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -126,6 +126,11 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=7.1.3",
+        "ext-curl": "*",
+        "ext-mbstring": "*",
+        "ext-zip": "*"
+    },
     "platform-dev": []
 }

--- a/index.php
+++ b/index.php
@@ -16,9 +16,9 @@ define('VERSION', '3.0.0');
 mb_internal_encoding('UTF-8');
 
 try {
-	$Wcms = new Wcms();
-	$Wcms->init();
-	$Wcms->render();
+    $Wcms = new Wcms();
+    $Wcms->init();
+    $Wcms->render();
 } catch (Exception $e) {
-	echo $e->getMessage();
+    echo $e->getMessage();
 }

--- a/src/classes/Wcms.php
+++ b/src/classes/Wcms.php
@@ -7,7 +7,10 @@
  */
 namespace Robiso\Wondercms;
 
-use Exception;
+use InvalidArgumentException;
+use Robiso\Wondercms\Exceptions\FilesystemErrorException;
+use Robiso\Wondercms\Exceptions\InvalidTokenException;
+use RuntimeException;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -246,11 +249,11 @@ class Wcms
     {
         // check folder is here
         if (!is_dir($folder) && !mkdir($folder, 0700) && !is_dir($folder)) {
-            throw new Exception(sprintf('Could not create the data folder! (%s). Check documentation to resolve this issue.', $folder));
+            throw new FilesystemErrorException(sprintf('Could not create the data folder! (%s). Check documentation to resolve this issue.', $folder));
         }
         // and check we can write to it
         if (!is_writable($folder)) {
-            throw new Exception(sprintf('Cannot write in folder: %s!. Check documentation to resolve this issue.', $folder));
+            throw new FilesystemErrorException(sprintf('Cannot write in folder: %s!. Check documentation to resolve this issue.', $folder));
         }
     }
 
@@ -553,7 +556,7 @@ class Wcms
             case 4:
                 return $this->db->{$args[0]}->{$args[1]}->{$args[2]}->{$args[3]};
             default:
-                throw new Exception('Too many arguments to get()');
+                throw new InvalidArgumentException('Too many arguments to get()');
         }
     }
 
@@ -571,7 +574,7 @@ class Wcms
         curl_setopt($ch, CURLOPT_URL, $repoUrl . $file);
         $content = curl_exec($ch);
         if ($content === false) {
-            throw new Exception('Cannot get content from repository!');
+            throw new RuntimeException('Cannot get content from repository!');
         }
         curl_close($ch);
         // cast to string because curl_exec() can return true
@@ -620,10 +623,10 @@ class Wcms
         }
 
         if (!\hash_equals($_POST['token'], $this->getToken())) {
-            throw new Exception('Invalid token');
+            throw new InvalidTokenException('Invalid token');
         }
         if (!\filter_var($_POST['addonURL'], FILTER_VALIDATE_URL)) {
-            throw new Exception('Invalid addon URL');
+            throw new InvalidArgumentException('Invalid addon URL');
         }
         $addonURL = $_POST['addonURL'];
 
@@ -1096,7 +1099,7 @@ EOT;
                 $this->redirect();
             }
             if (!move_uploaded_file($_FILES['uploadFile']['tmp_name'], $this->filesPath . '/' . basename($_FILES['uploadFile']['name']))) {
-                throw new Exception('Failed to move uploaded file!');
+                throw new FilesystemErrorException('Failed to move uploaded file!');
             }
             $this->alert('success', 'File uploaded.');
             $this->redirect();
@@ -1122,13 +1125,13 @@ EOT;
     private function zipBackup(): void
     {
         if (!\extension_loaded('zip')) {
-            throw new Exception('Zip extension is not loaded!');
+            throw new RuntimeException('Zip extension is not loaded!');
         }
         $zipName = date('Y-m-d') . '-wcms-backup-' . \bin2hex(\random_bytes(8)) . '.zip';
         $zipPath = $this->rootDir . '/files/' . $zipName;
         $zip = new \ZipArchive();
         if ($zip->open($zipPath, \ZipArchive::CREATE) !== true) {
-            throw new Exception('Cannot create the zip archive!');
+            throw new FilesystemErrorException('Cannot create the zip archive!');
         }
         $iterator = new \RecursiveDirectoryIterator($this->rootDir);
         $iterator->setFlags(\RecursiveDirectoryIterator::SKIP_DOTS);

--- a/src/exceptions/FilesystemErrorException.php
+++ b/src/exceptions/FilesystemErrorException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Robiso\Wondercms\Exceptions;
+
+/**
+ * For filesystem related errors
+ */
+class FilesystemErrorException extends \Exception
+{
+}

--- a/src/exceptions/InvalidTokenException.php
+++ b/src/exceptions/InvalidTokenException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Robiso\Wondercms\Exceptions;
+
+/**
+ * When CSRF token is invalid
+ */
+class InvalidTokenException extends \Exception
+{
+}


### PR DESCRIPTION
Now the code doesn't throw a generic Exception anymore (bad practice)
Add two custom exceptions: for filesystem related issues, and for
invalid token.
Also update the composer.lock and composer dependencies
Right now all exceptions are handled the same way, but this change at
least allows to handle them differently in the future.

You might think: but what could be the use of having different exceptions? Example: the invalid token exception might be logged as it might be a hacking attempt. As for the FilesystemError, maybe we just want to show the user a generic error message ("Something went wrong!"), but log a complete and more verbose error so the admin can see what went wrong. This prevent accidentally disclosing info to the attacker.