### PR TITLE
Fix page ordering. Fix part 1 of #134

### DIFF
--- a/src/classes/Wcms.php
+++ b/src/classes/Wcms.php
@@ -805,18 +805,36 @@ EOT;
         }
     }
 
+    /**
+     * Reorder the pages
+     *
+     * @param int $content 1 for down arrow, or -1 for up arrow clicked
+     * @param int $menu
+     * @return void
+     */
     private function orderMenuItem(int $content, int $menu): void
     {
+        // check if content is 1 or -1 as only those values are acceptable
+        if (!in_array($content, [1, -1])) {
+            throw new InvalidArgumentException('Bad content value.');
+        }
+
         $conf = 'config';
         $field = 'menuItems';
-        $content = (int) trim(htmlentities($content, ENT_QUOTES, 'UTF-8'));
+
+        $targetPosition = $menu + $content;
+
+        // save the target to avoid overwrite
+        // use clone to copy the object entirely
+        $tmp = clone $this->get($conf, $field, $targetPosition);
         $move = $this->get($conf, $field, $menu);
-        $menu += $content;
-        $this->set($conf, $field, $menu, 'name', $move->name);
-        $this->set($conf, $field, $menu, 'slug', $move->slug);
-        $this->set($conf, $field, $menu, 'visibility', $move->visibility);
-        $menu -= $content;
-        $tmp = $this->get($conf, $field, $menu);
+
+        // move the menu to new position
+        $this->set($conf, $field, $targetPosition, 'name', $move->name);
+        $this->set($conf, $field, $targetPosition, 'slug', $move->slug);
+        $this->set($conf, $field, $targetPosition, 'visibility', $move->visibility);
+
+        // now write the other one in the previous position
         $this->set($conf, $field, $menu, 'name', $tmp->name);
         $this->set($conf, $field, $menu, 'slug', $tmp->slug);
         $this->set($conf, $field, $menu, 'visibility', $tmp->visibility);
@@ -897,7 +915,7 @@ EOT;
                 $this->set('config', $fieldname, $menu, 'visibility', $visibility);
             }
             if ($target === 'menuItemOrder') {
-                $this->orderMenuItem($content, $menu);
+                $this->orderMenuItem((int) $content, (int) $menu);
             }
             if ($fieldname === 'defaultPage') {
                 if (!isset($this->get('pages')->$content)) {

--- a/src/js/admin.js
+++ b/src/js/admin.js
@@ -18,6 +18,13 @@ function fieldSave(a, b, c, d, e) {
     });
 }
 
+// Add slugify function to strings
+String.prototype.slugify = function() {
+  return toLowerCase().trim()
+      .replace(/&/g, '-and-')         // Replace & with 'and'
+      .replace(/[\s\W-]+/g, '-')      // Replace spaces, non-word characters and dashes with a single dash (-)
+}
+
 var changing = !1;
 $(document).ready(function() {
     $('body').on('click', 'div.editText', function() {
@@ -48,11 +55,10 @@ $(document).ready(function() {
         if (!newPage) {
             return !1;
         }
-        newPage = newPage.replace(/[`~;:'",.<>\{\}\[\]\\\/]/gi, '').trim();
         $.post("", {
             fieldname: "menuItems",
             token: token,
-            content: newPage,
+            content: newPage.slugify(),
             target: "menuItem",
             menu: "none",
             visibility: "show"


### PR DESCRIPTION
It was necessary to clone the object to avoid overwriting it. Also add a
slugify function to strings in javascript to make a slug from a string.