### PR TITLE
Security hardening: theme path traversal, protected config keys, safe file delete

### DIFF
--- a/index.php
+++ b/index.php
@@ -1015,6 +1015,9 @@ EOT;
 				'',
 				trim($_REQUEST['deleteModule'])
 			);
+			if (in_array($filename, ['', '.', '..'], true)) {
+				return;
+			}
 			$type = str_ireplace(
 				['/', './', '../', '..', '~', '~/', '\\'],
 				'',
@@ -2085,7 +2088,11 @@ EOT;
 	 */
 	public function loadThemeAndFunctions(): void
 	{
-		$location = $this->rootDir . '/themes/' . $this->get('config', 'theme');
+		$theme = preg_replace('/[^a-zA-Z0-9_-]/', '', (string) $this->get('config', 'theme'));
+		if ($theme === '' || !is_dir($this->rootDir . '/themes/' . $theme)) {
+			$theme = 'sky';
+		}
+		$location = $this->rootDir . '/themes/' . $theme;
 		if (file_exists($location . '/functions.php')) {
 			require_once $location . '/functions.php';
 		}
@@ -2628,6 +2635,9 @@ EOT;
 				$this->orderMenuItem($content, $menu);
 			}
 			if ($target === 'config') {
+				if (in_array($fieldname, ['password', 'customModules', 'menuItems', 'forceLogout', 'lastLogins', self::DISABLED_PLUGINS_KEY], true)) {
+					return;
+				}
 				if ($fieldname === 'defaultPage' && $content === 'blog') {
 					$this->set('config', $fieldname, $content);
 				} else {

--- a/index.php
+++ b/index.php
@@ -304,7 +304,18 @@ class Wcms
 	 */
 	public function asset(string $location): string
 	{
-		return self::url('themes/' . $this->get('config', 'theme') . '/' . $location);
+		return self::url('themes/' . $this->activeTheme() . '/' . $location);
+	}
+
+	/**
+	 * Sanitised active theme folder name, jailed to themes/ with a safe fallback.
+	 *
+	 * @return string
+	 */
+	public function activeTheme(): string
+	{
+		$theme = preg_replace('/[^a-zA-Z0-9_-]/', '', (string) $this->get('config', 'theme'));
+		return ($theme !== '' && is_dir($this->rootDir . '/themes/' . $theme)) ? $theme : 'sky';
 	}
 
 	/**
@@ -1016,7 +1027,8 @@ EOT;
 				trim($_REQUEST['deleteModule'])
 			);
 			if (in_array($filename, ['', '.', '..'], true)) {
-				return;
+				$this->alert('danger', 'Invalid file name.');
+				$this->redirect();
 			}
 			$type = str_ireplace(
 				['/', './', '../', '..', '~', '~/', '\\'],
@@ -2088,11 +2100,7 @@ EOT;
 	 */
 	public function loadThemeAndFunctions(): void
 	{
-		$theme = preg_replace('/[^a-zA-Z0-9_-]/', '', (string) $this->get('config', 'theme'));
-		if ($theme === '' || !is_dir($this->rootDir . '/themes/' . $theme)) {
-			$theme = 'sky';
-		}
-		$location = $this->rootDir . '/themes/' . $theme;
+		$location = $this->rootDir . '/themes/' . $this->activeTheme();
 		if (file_exists($location . '/functions.php')) {
 			require_once $location . '/functions.php';
 		}
@@ -2638,22 +2646,15 @@ EOT;
 				if (in_array($fieldname, ['password', 'customModules', 'menuItems', 'forceLogout', 'lastLogins', self::DISABLED_PLUGINS_KEY], true)) {
 					return;
 				}
-				if ($fieldname === 'defaultPage' && $content === 'blog') {
-					$this->set('config', $fieldname, $content);
-				} else {
-					if ($fieldname === 'defaultPage' && $this->getPageData($content) === null) {
-						return;
-					}
-					$this->set('config', $fieldname, $content);
+				if ($fieldname === 'defaultPage' && $content !== 'blog' && $this->getPageData($content) === null) {
+					return;
 				}
-			}
-			if ($fieldname === 'login' && (empty($content) || $this->getPageData($content) !== null)) {
-				return;
-			}
-			if ($fieldname === 'theme' && !is_dir($this->rootDir . '/themes/' . $content)) {
-				return;
-			}
-			if ($target === 'config') {
+				if ($fieldname === 'login' && (empty($content) || $this->getPageData($content) !== null)) {
+					return;
+				}
+				if ($fieldname === 'theme' && (basename($content) !== $content || !is_dir($this->rootDir . '/themes/' . $content))) {
+					return;
+				}
 				$this->set('config', $fieldname, $content);
 			} elseif ($target === 'blocks') {
 				$this->set('blocks', $fieldname, 'content', $content);


### PR DESCRIPTION
## Summary

Three authenticated-admin security defects in `index.php`, plus a follow-up cleanup. All changes preserve WonderCMS's single-admin trust model and were verified against the real plugin/theme ecosystem (robiso/* plugins, sky/bike themes) — no plugin or theme behaviour changes.

### Commit 1 — security fixes
- **Theme path traversal (LFI), jailed at the load sink.** `loadThemeAndFunctions()` now sanitises `config.theme` (charset-strip + `is_dir` + `sky` fallback) before building the `require` path, so a poisoned theme value can't escape `themes/` regardless of which writer stored it.
- **Protected config keys via `saveAction()`.** The generic `target=config` path now refuses `password`, `customModules`, `menuItems`, `forceLogout`, `lastLogins`, `disabledPlugins`, so the dedicated re-authenticated handlers (old-password check, `password_recheck`) can't be bypassed.
- **Whole-directory delete via empty/dot filename.** `deleteFileModuleAction()` rejects `''`, `.`, `..` — inputs that `str_ireplace` can collapse a traversal into — which otherwise `realpath` to a directory root and `recursiveDelete` the entire `files/` / `plugins/` / `themes/` (or parent) tree.

### Commit 2 — cleanup / consolidation
- Add `activeTheme()`: a single sanitised source for the active theme, shared by `asset()` and `loadThemeAndFunctions()`, so asset URLs and the require path can no longer diverge.
- `saveAction()`: validate `defaultPage` / `login` / `theme` **before** a **single** config write — removing a duplicate write and a write-before-validate bug (invalid values were persisted, then "rejected"). The theme check now rejects path traversal (`basename` mismatch), not just missing directories.
- `deleteFileModuleAction()`: the rejected empty/dot filename now alerts + redirects, matching the sibling invalid-type message.

## Threat model
Single-admin, trusted; the CSRF token is `random_bytes(32)` + `hash_equals` (no blind CSRF). These are defense-in-depth / cross-writer / jail-escape fixes, not self-attacks.

## Compatibility
No backwards-compatibility breaks. Verified against contact-form (writes custom `contactForm*` config keys — unaffected), simple-seo (reads `menuItems`), simple-blog (own save path), and the sky/bike themes; no plugin registers a `save` listener, and real theme names are `[a-zA-Z0-9_-]` so `activeTheme()` is a no-op for them.
